### PR TITLE
add case-filter option

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ const DEFAULT_VRCAT_PATH = "/AppData/LocalLow/VRChat/VRChat";
 export interface appParameterObject {
     import?: string;
     filter?: string[];
+    caseFilter?: string[];
     verbose?: boolean;
     range: string;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,8 @@ program
 
 program
     .description("VRChat log viewer")
-    .option("-f, --filter <word...>", "filter logs with words")
+    .option("-f, --filter <word...>", "filter logs with ignore case words")
+    .option("-cf, --case-filter <word...>", "filter logs with no ignore case words")
     .option("-i, --import <dir>", "log directory to import additional")
     .option("-V, --verbose", "display full log details")
     .option("-r, --range <hours>", "specify the range to display", "24")
@@ -16,6 +17,7 @@ export async function run(argv: any): Promise<void> {
     app({
         import: program["import"],
         filter: program["filter"],
+        caseFilter: program["caseFilter"],
         verbose: program["verbose"],
         range: program["range"]
     });

--- a/src/util/showLog.ts
+++ b/src/util/showLog.ts
@@ -2,12 +2,14 @@ import { appParameterObject } from "../app";
 import { ActivityLog, ActivityType, MoveActivityLog, EnterActivityLog, SendNotificationActivityLog, ReceiveNotificationActivityLog, AuthenticationActivityLog, CheckBuildActivityLog, ShutdownActivityLog } from "../type/logType";
 
 export function showLog(param: appParameterObject, activityLog: ActivityLog[]): void {
+    console.log(param);
+    const ignoreCaseFilter = param.filter?.map(e => e.toLowerCase());
     const matchedLogs: string[] = [];
 
     const currentTime = Date.now();
     const rangeMillisecond = (param.range ? parseInt(param.range, 10) : 24) * 60 * 60 * 1000;
     const showableRangeLog = activityLog.filter(e => currentTime - e.date < rangeMillisecond);
-    const dateOption = {
+    const dateOption: Intl.DateTimeFormatOptions = {
         year: "numeric", month: "2-digit", day: "2-digit",
         hour: "2-digit", minute: "2-digit", second: "2-digit"
     };
@@ -38,10 +40,14 @@ export function showLog(param: appParameterObject, activityLog: ActivityLog[]): 
                 message += generateShutdownMessage(e as ShutdownActivityLog);
                 break;
         }
-        if (!param.filter) {
+        if (!param.filter && !param.caseFilter) {
             matchedLogs.push(message);
-        } else if (isMatchFilter(message, param.filter)) {
-            matchedLogs.push(message);
+        } else if (param.caseFilter) {
+            if (isMatchFilter(message, param.caseFilter)) matchedLogs.push(message);
+        } else if (param.filter) {
+            const lowerMessage = message.toLowerCase();
+            // param.filterとignoreCaseFilterのnullableは同じ
+            if (isMatchFilter(lowerMessage, ignoreCaseFilter!)) matchedLogs.push(message);
         }
     });
     console.log(matchedLogs.join("\n"));


### PR DESCRIPTION
従来のフィルタオプションを `-cf` `--case-filter` にリネームします。
このフィルタは大文字小文字を区別します。

また、従来の `-f` `--filter` オプションは大文字小文字を区別しない挙動に変更します。
大文字小文字の区別は、フィルタする文字列・される文字列の両方でされなくなります。